### PR TITLE
Add --csv to output in a CSV format

### DIFF
--- a/Classes/Command/SlugRegeneratorCommand.php
+++ b/Classes/Command/SlugRegeneratorCommand.php
@@ -37,6 +37,7 @@ class SlugRegeneratorCommand extends Command implements LoggerAwareInterface
         $this->setDescription($this->commandDescription)
             ->setHelp($this->commandHelp)
             ->addOption('dry-mode','-d', InputOption::VALUE_NONE, 'do not change anything')
+            ->addOption('csv','-c', InputOption::VALUE_NONE, 'output in csv format')
             ->addOption('redirects','-r', InputOption::VALUE_OPTIONAL, 'create redirects for changed slugs with this TTL in days', 30)
             ->addArgument('root-page', InputArgument::REQUIRED)
         ;
@@ -56,6 +57,7 @@ class SlugRegeneratorCommand extends Command implements LoggerAwareInterface
     {
         $io = new SymfonyStyle($input, $output);
         $dryMode = (bool)$input->getOption('dry-mode');
+        $outputFormat = (bool)$input->getOption('csv') ? 'csv' : 'plain';
         $redirectsOption = $input->getOption('redirects');
         if (false === $redirectsOption) {
             // option not passed
@@ -74,7 +76,8 @@ class SlugRegeneratorCommand extends Command implements LoggerAwareInterface
             $io,
             $this->logger,
             $dryMode,
-            $createRedirects
+            $createRedirects,
+            $outputFormat
         );
         $migration->execute((int)$rootPage);
 


### PR DESCRIPTION
For analysis in Excel & Co of what changed in the Slug structure, an easier output format. Works well with `--dry-run`, i.e:.

```
bin/typo3cms sluggy:regenerate --dry-mode --csv -- 1 > changes.csv
```

The output contains:
* `pid`
* old slug
* new slug (or string "*UNCHANGED*" in case it did not change)